### PR TITLE
init: Add top-level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+# UNIVERSAL
+*.user
+*.bak
+*~
+
+# DO NOT COMMIT PRIVATE KEYS! This section prevents accidental leaks.
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*.key
+*.ppk 
+*.pem
+
+# OUTPUT
+build/
+install/
+
+# CMAKE
+CMakeLists.txt.user
+CMakeUserPresets.json
+
+# VISUAL STUDIO
+.vs/
+
+# VSCODE
+.vscode/
+
+# JETBRAINS
+.idea/
+
+# XCODE
+xcuserdata/
+
+# SUBLIMETEXT
+*.sublime-workspace
+
+# EMACS
+.#*
+
+# VIM
+Session.vim
+Sessionx.vim
+.netrwhist
+[._]*.un~
+[._]*.sw[a-p]
+
+# OS/Platform junk
+.DS_Store
+Thumbs.db
+.fuse_hidden*
+.directory
+.Trash-*
+.nfs*
+nohup.out


### PR DESCRIPTION
Output directories are ignored but not individual output file types, so in-source outputs (if any) remain visible/tracked locally and can be cleaned up. CI/workflows should be used instead to prevent accidental commits of build artifacts or other unwanted files, instead of ignoring by file type.

IDE/editor-specific user files are ignored so users can keep their custom environment files (e.g., .user, .vs/, .idea/) across cleans.

Private key patterns (id_rsa, *.pem, *.ppk, etc.) are ignored to reduce the risk of accidental credentials leakage.