### PR TITLE
docs(readme): remove navigation links from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 [![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2.svg)](https://discord.gg/CRZDZEhR5p)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/CommunityRTS/MinGenerals)
 
-[Getting Started](#getting-started) • [Building](#building) • [Dependencies](#dependencies)
-
 </div>
 
 This repository includes modified source code from Command & Conquer Generals, and its expansion pack Zero Hour.


### PR DESCRIPTION
Removed the unnecessary navigation links from the header of the README. The navigation links are unnecessary because the README is not long enough to warrant their existence.