### PR TITLE
Fix Zero Hour CD prompts

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/CDCheck.h
+++ b/Generals/Code/GameEngine/Include/GameClient/CDCheck.h
@@ -32,9 +32,6 @@
 #ifndef __CDCHECK_H_
 #define __CDCHECK_H_
 
-typedef void (*gameStartCallback) (void);
-
-Bool IsFirstCDPresent(void);
-void CheckForCDAtGameStart( gameStartCallback callback );
+// Legacy CD check removed; discs are no longer required.
 
 #endif //__CDCHECK_H_

--- a/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -254,38 +254,8 @@ Bool FileSystem::createDirectory(AsciiString directory)
 //============================================================================
 Bool FileSystem::areMusicFilesOnCD()
 {
-#if 1
-	return TRUE;
-#else
-	if (!TheCDManager) {
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - No CD Manager; returning false\n"));
-		return FALSE;
-	}
-
-	AsciiString cdRoot;
-	Int dc = TheCDManager->driveCount();
-	for (Int i = 0; i < dc; ++i) {
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - checking drive %d\n", i));
-		CDDriveInterface *cdi = TheCDManager->getDrive(i);
-		if (!cdi) {
-			continue;
-		}
-
-		cdRoot = cdi->getPath();
-		if (!cdRoot.endsWith("\\"))
-			cdRoot.concat("\\");
-		cdRoot.concat("gensec.big");
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - checking for %s\n", cdRoot.str()));
-		File *musicBig = TheLocalFileSystem->openFile(cdRoot.str());
-		if (musicBig)
-		{
-			DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - found it!\n"));
-			musicBig->close();
-			return TRUE;
-		}
-	}
-	return FALSE;
-#endif
+        // Always succeed; music is expected to be installed locally.
+        return TRUE;
 }
 //============================================================================
 // FileSystem::loadMusicFilesFromCD

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -70,7 +70,6 @@
 #include "GameNetwork/DownloadManager.h"
 #include "GameNetwork/GameSpy/MainMenuUtils.h"
 
-#include "GameClient/CDCheck.h"
 //Added By Saad
 //for accessing the InGameUI
 #include "GameClient/InGameUI.h"
@@ -279,24 +278,6 @@ void prepareCampaignGame(GameDifficulty diff)
 	setupGameStart(TheCampaignManager->getCurrentMap(), diff );
 }
 
-static MessageBoxReturnType cancelStartBecauseOfNoCD( void *userData )
-{
-	return MB_RETURN_CLOSE;
-}
-
-static MessageBoxReturnType checkCDCallback( void *userData )
-{
-	if (!IsFirstCDPresent())
-	{
-		return MB_RETURN_KEEPOPEN;
-	}
-	else
-	{
-		prepareCampaignGame((GameDifficulty)(Int)(Int *)userData);
-		return MB_RETURN_CLOSE;
-	}
-}
-
 static void doGameStart( void )
 {
 #if !defined(_PLAYTEST)
@@ -318,16 +299,7 @@ static void doGameStart( void )
 
 static void checkCDBeforeCampaign(GameDifficulty diff)
 {
-	if (!IsFirstCDPresent())
-	{
-		// popup a dialog asking for a CD
-		ExMessageBoxOkCancel(TheGameText->fetch("GUI:InsertCDPrompt"), TheGameText->fetch("GUI:InsertCDMessage"),
-			(void *)diff, checkCDCallback, cancelStartBecauseOfNoCD);
-	}
-	else
-	{
-		prepareCampaignGame(diff);
-	}
+        prepareCampaignGame(diff);
 }
 
 static void shutdownComplete( WindowLayout *layout )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -72,7 +72,6 @@
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/VictoryConditions.h"
-#include "GameClient/CDCheck.h"
 #include "GameClient/Display.h"
 #include "GameClient/GUICallbacks.h"
 #include "GameClient/WindowLayout.h"
@@ -471,7 +470,7 @@ WindowMsgHandledType ScoreScreenSystem( GameWindow *window, UnsignedInt msg,
 					}
 					else
 					{
-						CheckForCDAtGameStart( startNextCampaignGame );
+                                            startNextCampaignGame();
 					}
 				}
 #endif

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -59,7 +59,6 @@
 
 #include "Common/MultiplayerSettings.h"
 #include "GameClient/GameText.h"
-#include "GameClient/CDCheck.h"
 #include "GameClient/ExtendedMessageBox.h"
 #include "GameClient/MessageBox.h"
 #include "GameNetwork/GameInfo.h"
@@ -403,50 +402,6 @@ void reallyDoStart( void )
 	}
 }
 
-static MessageBoxReturnType cancelStartBecauseOfNoCD( void *userData )
-{
-	buttonPushed = FALSE;
-	return MB_RETURN_CLOSE;
-}
-
-Bool IsFirstCDPresent(void)
-{
-#if !defined(_INTERNAL) && !defined(_DEBUG)
-	return TheFileSystem->areMusicFilesOnCD();
-#else
-	return TRUE;
-#endif
-}
-
-static MessageBoxReturnType checkCDCallback( void *userData )
-{
-	if (!IsFirstCDPresent())
-	{
-		return (IsFirstCDPresent())?MB_RETURN_CLOSE:MB_RETURN_KEEPOPEN;
-	}
-	else
-	{
-		gameStartCallback callback = (gameStartCallback)userData;
-		if (callback)
-			callback();
-		return MB_RETURN_CLOSE;
-	}
-}
-
-void CheckForCDAtGameStart( gameStartCallback callback )
-{
-	if (!IsFirstCDPresent())
-	{
-		// popup a dialog asking for a CD
-		ExMessageBoxOkCancel(TheGameText->fetch("GUI:InsertCDPrompt"), TheGameText->fetch("GUI:InsertCDMessage"),
-			callback, checkCDCallback, cancelStartBecauseOfNoCD);
-	}
-	else
-	{
-		callback();
-	}
-}
-
 Bool sandboxOk = FALSE;
 static void startPressed(void)
 {
@@ -481,12 +436,10 @@ static void startPressed(void)
 		isReady = TRUE;
 	}
 	
-#if !defined(_PLAYTEST)
-	if(isReady)
-	{
-		CheckForCDAtGameStart( reallyDoStart );
-	}
-#endif
+        if(isReady)
+        {
+                reallyDoStart();
+        }
 
 }//void startPressed(void)
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ArchiveFileSystem.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ArchiveFileSystem.h
@@ -46,7 +46,7 @@
 #ifndef __ARCHIVEFILESYSTEM_H_
 #define __ARCHIVEFILESYSTEM_H_
 
-#define MUSIC_BIG "Music.big"
+#define MUSIC_BIG "MusicZH.big"
 
 //----------------------------------------------------------------------------
 //           Includes                                                      

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/CDCheck.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/CDCheck.h
@@ -32,9 +32,6 @@
 #ifndef __CDCHECK_H_
 #define __CDCHECK_H_
 
-typedef void (*gameStartCallback) (void);
-
-Bool IsFirstCDPresent(void);
-void CheckForCDAtGameStart( gameStartCallback callback );
+// Legacy CD check removed; discs are no longer required.
 
 #endif //__CDCHECK_H_

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -575,31 +575,12 @@ void GameEngine::init( int argc, char *argv[] )
 		// load music dialog will still cause the game to quit.
 		// m_quitting = FALSE;
 
-		// for fingerprinting, we need to ensure the presence of these files
-
-
-#if !defined(_INTERNAL) && !defined(_DEBUG)
-		AsciiString dirName;
-    dirName = TheArchiveFileSystem->getArchiveFilenameForFile("generalsbzh.sec");
-
-    if (dirName.compareNoCase("genseczh.big") != 0)
-		{
-			DEBUG_LOG(("generalsbzh.sec was not found in genseczh.big - it was in '%s'\n", dirName.str()));
-			m_quitting = TRUE;
-		}
-		
-		dirName = TheArchiveFileSystem->getArchiveFilenameForFile("generalsazh.sec");
-		const char *noPath = dirName.reverseFind('\\');
-		if (noPath) {
-			dirName = noPath + 1;
-		}
-
-		if (dirName.compareNoCase("musiczh.big") != 0)
-		{
-			DEBUG_LOG(("generalsazh.sec was not found in musiczh.big - it was in '%s'\n", dirName.str()));
-			m_quitting = TRUE;
-		}
-#endif
+                // Legacy disc fingerprinting relied on hidden `.sec` files packaged
+                // within `genseczh.big` and `musiczh.big`. If those files were not
+                // found, the game would quit and prompt for the original discs.
+                // This copy protection is obsolete for the open-source release, so
+                // the checks have been removed to allow running purely from the
+                // installed data without requiring any game media.
 
 
 		// initialize the MapCache

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -266,34 +266,8 @@ Bool FileSystem::createDirectory(AsciiString directory)
 //============================================================================
 Bool FileSystem::areMusicFilesOnCD()
 {
-	if (!TheCDManager) {
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - No CD Manager; returning false\n"));
-		return FALSE;
-	}
-
-	AsciiString cdRoot;
-	Int dc = TheCDManager->driveCount();
-	for (Int i = 0; i < dc; ++i) {
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - checking drive %d\n", i));
-		CDDriveInterface *cdi = TheCDManager->getDrive(i);
-		if (!cdi) {
-			continue;
-		}
-
-		cdRoot = cdi->getPath();
-		if (!cdRoot.endsWith("\\"))
-			cdRoot.concat("\\");
-		cdRoot.concat("genseczh.big");
-		DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - checking for %s\n", cdRoot.str()));
-		File *musicBig = TheLocalFileSystem->openFile(cdRoot.str());
-		if (musicBig)
-		{
-			DEBUG_LOG(("FileSystem::areMusicFilesOnCD() - found it!\n"));
-			musicBig->close();
-			return TRUE;
-		}
-	}
-	return FALSE;
+        // Always succeed; music is expected to be installed locally.
+        return TRUE;
 }
 //============================================================================
 // FileSystem::loadMusicFilesFromCD

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -73,7 +73,6 @@
 #include "GameNetwork/DownloadManager.h"
 #include "GameNetwork/GameSpy/MainMenuUtils.h"
 
-#include "GameClient/CDCheck.h"
 //Added By Saad
 //for accessing the InGameUI
 #include "GameClient/InGameUI.h"
@@ -309,24 +308,6 @@ void prepareCampaignGame(GameDifficulty diff)
 	setupGameStart(TheCampaignManager->getCurrentMap(), diff );
 }
 
-static MessageBoxReturnType cancelStartBecauseOfNoCD( void *userData )
-{
-	return MB_RETURN_CLOSE;
-}
-
-static MessageBoxReturnType checkCDCallback( void *userData )
-{
-	if (!IsFirstCDPresent())
-	{
-		return MB_RETURN_KEEPOPEN;
-	}
-	else
-	{
-		prepareCampaignGame((GameDifficulty)(Int)(Int *)userData);
-		return MB_RETURN_CLOSE;
-	}
-}
-
 static void doGameStart( void )
 {
 	startGame = FALSE;
@@ -346,16 +327,7 @@ static void doGameStart( void )
 
 static void checkCDBeforeCampaign(GameDifficulty diff)
 {
-	if (!IsFirstCDPresent())
-	{
-		// popup a dialog asking for a CD
-		ExMessageBoxOkCancel(TheGameText->fetch("GUI:InsertCDPrompt"), TheGameText->fetch("GUI:InsertCDMessage"),
-			(void *)diff, checkCDCallback, cancelStartBecauseOfNoCD);
-	}
-	else
-	{
-		prepareCampaignGame(diff);
-	}
+        prepareCampaignGame(diff);
 }
 
 static void shutdownComplete( WindowLayout *layout )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -75,7 +75,6 @@
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/ScriptEngine.h"
 #include "GameLogic/VictoryConditions.h"
-#include "GameClient/CDCheck.h"
 #include "GameClient/Display.h"
 #include "GameClient/GUICallbacks.h"
 #include "GameClient/WindowLayout.h"
@@ -558,7 +557,7 @@ WindowMsgHandledType ScoreScreenSystem( GameWindow *window, UnsignedInt msg,
 					}
 					else
 					{
-						CheckForCDAtGameStart( startNextCampaignGame );
+                                                startNextCampaignGame();
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -61,7 +61,6 @@
 
 #include "Common/MultiplayerSettings.h"
 #include "GameClient/GameText.h"
-#include "GameClient/CDCheck.h"
 #include "GameClient/ExtendedMessageBox.h"
 #include "GameClient/MessageBox.h"
 #include "GameNetwork/GameInfo.h"
@@ -458,50 +457,6 @@ void reallyDoStart( void )
 	}
 }
 
-static MessageBoxReturnType cancelStartBecauseOfNoCD( void *userData )
-{
-	buttonPushed = FALSE;
-	return MB_RETURN_CLOSE;
-}
-
-Bool IsFirstCDPresent(void)
-{
-#if !defined(_INTERNAL) && !defined(_DEBUG)
-	return TheFileSystem->areMusicFilesOnCD();
-#else
-	return TRUE;
-#endif
-}
-
-static MessageBoxReturnType checkCDCallback( void *userData )
-{
-	if (!IsFirstCDPresent())
-	{
-		return (IsFirstCDPresent())?MB_RETURN_CLOSE:MB_RETURN_KEEPOPEN;
-	}
-	else
-	{
-		gameStartCallback callback = (gameStartCallback)userData;
-		if (callback)
-			callback();
-		return MB_RETURN_CLOSE;
-	}
-}
-
-void CheckForCDAtGameStart( gameStartCallback callback )
-{
-	if (!IsFirstCDPresent())
-	{
-		// popup a dialog asking for a CD
-		ExMessageBoxOkCancel(TheGameText->fetch("GUI:InsertCDPrompt"), TheGameText->fetch("GUI:InsertCDMessage"),
-			callback, checkCDCallback, cancelStartBecauseOfNoCD);
-	}
-	else
-	{
-		callback();
-	}
-}
-
 Bool sandboxOk = FALSE;
 static void startPressed(void)
 {
@@ -536,10 +491,10 @@ static void startPressed(void)
 		isReady = TRUE;
 	}
 	
-	if(isReady)
-	{
-		CheckForCDAtGameStart( reallyDoStart );
-	}
+        if(isReady)
+        {
+                reallyDoStart();
+        }
 
 }//void startPressed(void)
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -397,7 +397,7 @@ BOOL CWorldBuilderApp::InitInstance()
 	//  [2/11/2003]
 	ini.load( AsciiString( "Data\\Scripts\\Scripts.ini" ), INI_LOAD_OVERWRITE, NULL );
 
-	// need this before TheAudio in case we're running off of CD - TheAudio can try to open Music.big on the CD...
+        // need this before TheAudio in case we're running off of CD - TheAudio can try to open MusicZH.big on the CD...
 	initSubsystem(TheCDManager, CreateCDManager(), NULL);
 	initSubsystem(TheAudio, (AudioManager*)new MilesAudioManager());
 	if (!TheAudio->isMusicAlreadyLoaded())


### PR DESCRIPTION
## Summary
- remove unused CDCheck interfaces and references
- stub out FileSystem::areMusicFilesOnCD to always succeed
- launch campaigns and skirmishes directly without CD prompts

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8239c3dd4832da83cb68d87fd4c12